### PR TITLE
最新版对iidestiny/flysystem-oss依赖包版本问题修复

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,25 @@
 {
-    "name": "iidestiny/laravel-filesystem-oss",
-    "description": "Oss storage filesystem for Laravel.",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "iidestiny",
-            "email": "iidestiny@vip.qq.com"
-        }
-    ],
-    "require": {
-        "php": "^7.0",
-        "iidestiny/flysystem-oss": "^1.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Iidestiny\\LaravelFilesystemOss\\": "src"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Iidestiny\\LaravelFilesystemOss\\OssStorageServiceProvider"
-            ]
-        }
+  "name": "iidestiny/laravel-filesystem-oss",
+  "description": "Oss storage filesystem for Laravel.",
+  "license": "MIT",
+  "authors": [{
+    "name": "iidestiny",
+    "email": "iidestiny@vip.qq.com"
+  }],
+  "require": {
+    "php": "^7.0",
+    "iidestiny/flysystem-oss": "^1.3.*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Iidestiny\\LaravelFilesystemOss\\": "src"
     }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Iidestiny\\LaravelFilesystemOss\\OssStorageServiceProvider"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
最新版`laravel-filesystem-oss`对`iidestiny/flysystem-oss`版本要求未更新，导致`plugins`不存在错误