### PR TITLE
feat: 支持 `url` 配置, 访问文件自动与上传端点进行区分

### DIFF
--- a/src/OssStorageServiceProvider.php
+++ b/src/OssStorageServiceProvider.php
@@ -44,6 +44,8 @@ class OssStorageServiceProvider extends ServiceProvider
                 $buckets
             );
 
+            $adapter->setCdnUrl($config['url'] ?? null);
+
             return new FilesystemAdapter(new Filesystem($adapter), $adapter, $config);
         });
     }


### PR DESCRIPTION
用adapter已有的`setCdnUrl`方法来解决访问&上传分离的功能。
此配置项类似 laravel 里 s3 的实现

实际上adapter库可能再扩展一个 `temporary_url` 选项会更好，因为实际使用场景下，最可能发生的情况是：
- 上传：使用阿里云内网(endpoint直接配置internal端点)
- 普通访问：公共读的文件使用cdn
- 签名访问：私有读的文件使用oss公网端点或加速端点(使用temporary_url配置项来区分)